### PR TITLE
feat: add Renovate config preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default preset for use with Parca's repos",
+  "extends": [
+    "config:base",
+    ":automergeDigest",
+    ":automergeMinor",
+    ":maintainLockFilesWeekly",
+    ":rebaseStalePrs",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    "regexManagers:dockerfileVersions"
+  ],
+  "reviewers": ["team:server-maintainers"],
+  "internalChecksFilter": "strict",
+  "platformAutomerge": true,
+  "golang": {
+    "postUpdateOptions": [
+      "gomodTidy",
+      "gomodUpdateImportPaths"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "One week stability period for Go, npm, and Rust packages",
+      "matchDatasources": ["go", "npm", "rust"],
+      "stabilityDays": 7
+    },
+    {
+      "description": "Update Go module digests weekly as they tend to update too often",
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["digest"],
+      "extends": ["schedule:weekly"]
+    },
+    {
+      "description": "Prefix lockFileMaintenance branches",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "additionalBranchPrefix": "{{{manager}}}-",
+      "commitMessagePrefix": "{{{semanticPrefix}}} {{{manager}}}"
+    },
+    {
+      "description": "Group golang docker tags and rename to Golang",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["golang"],
+      "matchPackagePatterns": ["/golang$"],
+      "commitMessageTopic": "Golang",
+      "groupName": "golang"
+    },
+    {
+      "description": "Group packages from Kubernetes together",
+      "matchSourceUrlPrefixes": ["https://github.com/kubernetes/"],
+      "matchUpdateTypes": ["patch", "minor", "major"],
+      "groupName": "kubernetes"
+    },
+    {
+      "description": "Exclude retracted Kubernetes client versions: https://github.com/renovatebot/renovate/issues/13012",
+      "matchPackageNames": ["k8s.io/client-go"],
+      "allowedVersions": "!/1\\.(4\\.0|5\\.0|5\\.1|5\\.2)$/"
+    },
+    {
+      "description": "Exclude retracted Prometheus versions: https://github.com/renovatebot/renovate/issues/13012",
+      "matchPackageNames": ["github.com/prometheus/prometheus"],
+      "allowedVersions": "<1"
+    },
+    {
+      "matchDepTypes": ["dependencies", "require"],
+      "semanticCommitType": "build"
+    },
+    {
+      "matchPackageNames": ["golang", "node", "rust"],
+      "matchUpdateTypes": ["patch", "minor", "major"],
+      "semanticCommitType": "build"
+    },
+    {
+      "matchFiles": ["Dockerfile"],
+      "semanticCommitType": "build"
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update _VERSION variables in GitHub workflows",
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s*[A-Z_]+?_VERSION: ('|\")?(?<currentValue>.+?)('|\")?\\s"
+      ]
+    },
+    {
+      "description": "Update _VERSION variables in Makefiles",
+      "fileMatch": ["(^|/)Makefile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s[A-Z_]+?_VERSION .?= (?<currentValue>.+?)\\s"
+      ]
+    },
+    {
+      "description": "Update _VERSION variables in shell scripts",
+      "fileMatch": ["\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s[A-Z_]+?_VERSION=('|\")?(?<currentValue>.+?)('|\")?\\s"
+      ]
+    },
+    {
+      "description": "Update Golang in go.mod file",
+      "fileMatch": ["(^|/)\\go.mod$"],
+      "matchStrings": ["\\sgo (?<currentValue>.+?)\\s"],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Update Golang in .go-version file",
+      "fileMatch": ["(^|/)\\.go-version$"],
+      "matchStrings": ["^\\s*(?<currentValue>.+?)\\s*$"],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Update Rust stable version in rust-toolchain.toml",
+      "fileMatch": ["(^|/)rust-toolchain\\.toml$"],
+      "matchStrings": ["channel\\s*=\\s*('|\")(?<currentValue>.+?)('|\")\\s"],
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
This is essentially the same config as the agent with the following changes:

* `team:server-maintainers` are the default `reviewers` for any repo using this preset. Override is possible like the agent will do with `team:agent-maintainers` (open to other name suggestions: `core-maintainers`, `maintainers`...)
* Add `npm` packages to "one week stability period" rule
* Change semantic commit type of `node` and `rust` updates to `build`
* Add regex manager for `.go-version` files. Along with [`.nvmrc` files (could be `.node-version` if the team prefers `nodenv`)](https://docs.renovatebot.com/node/#file-support), and similarly to `rust-toolchain.toml`, the files will have two purposes:
    * Centralize the version used in the workflows
    * Set the version for developers using a version manager (e.g. gvm/goenv, nvm)
* Finally, I proactively added a regex manager for `rust-toolchain.toml`. It will only work if the channel is a stable release.