### PR TITLE
fix(renovate): fix typo in go.mod regex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>parca-dev/.github"]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  LOG_LEVEL: debug
+
+jobs:
+  validate-renovate-config:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        file:
+          - default.json
+          - renovate-config.json
+    env:
+      RENOVATE_CONFIG_FILE: ${{ matrix.file }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - name: Validate Renovate Config
+        run: npx -p renovate renovate-config-validator

--- a/default.json
+++ b/default.json
@@ -107,7 +107,7 @@
     },
     {
       "description": "Update Golang in go.mod file",
-      "fileMatch": ["(^|/)\\go.mod$"],
+      "fileMatch": ["(^|/)go.mod$"],
       "matchStrings": ["\\sgo (?<currentValue>.+?)\\s"],
       "depNameTemplate": "golang",
       "datasourceTemplate": "docker"

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Onboarding preset for use with Parca's repos",
+  "extends": ["github>parca-dev/.github"]
+}


### PR DESCRIPTION
This fixes the typo and:

* adds a workflow to validate the config, so we do not risk breaking Renovate for all repositories depending on the preset
* adds a renovate config for this repository to update the action
* adds an org-level onboarding preset, which will be used as default when a repository in the org enables Renovate: https://docs.renovatebot.com/config-presets/#organization-level-presets

Related to parca-dev/parca-agent#505 (Renovate will close it itself if it is resolved) 