### PR TITLE
fix(renovate): opt-out minimum Go version updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,7 +30,7 @@
     },
     {
       "description": "One week stability period for Go, npm, and Rust packages",
-      "matchDatasources": ["go", "npm", "rust"],
+      "matchDatasources": ["go", "npm", "crate"],
       "stabilityDays": 7
     },
     {
@@ -46,12 +46,16 @@
       "commitMessagePrefix": "{{{semanticPrefix}}} {{{manager}}}"
     },
     {
-      "description": "Group golang docker tags and rename to Golang",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["golang"],
-      "matchPackagePatterns": ["/golang$"],
-      "commitMessageTopic": "Golang",
-      "groupName": "golang"
+      "description": "Group golang updates and rename to Go",
+      "matchDatasources": ["docker", "golang-version"],
+      "matchPackageNames": ["go", "golang"],
+      "commitMessageTopic": "Go",
+      "groupName": "go"
+    },
+    {
+      "description": "Customize rust updates commit message",
+      "matchPackageNames": ["rust"],
+      "commitMessageTopic": "Rust"
     },
     {
       "description": "Group packages from Kubernetes together",
@@ -74,7 +78,7 @@
       "semanticCommitType": "build"
     },
     {
-      "matchPackageNames": ["golang", "node", "rust"],
+      "matchPackageNames": ["go", "node", "rust"],
       "matchUpdateTypes": ["patch", "minor", "major"],
       "semanticCommitType": "build"
     },
@@ -106,18 +110,11 @@
       ]
     },
     {
-      "description": "Update Golang in go.mod file",
-      "fileMatch": ["(^|/)go.mod$"],
-      "matchStrings": ["\\sgo (?<currentValue>.+?)\\s"],
-      "depNameTemplate": "golang",
-      "datasourceTemplate": "docker"
-    },
-    {
       "description": "Update Golang in .go-version file",
       "fileMatch": ["(^|/)\\.go-version$"],
       "matchStrings": ["^\\s*(?<currentValue>.+?)\\s*$"],
-      "depNameTemplate": "golang",
-      "datasourceTemplate": "docker"
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version"
     },
     {
       "description": "Update Rust stable version in rust-toolchain.toml",

--- a/default.json
+++ b/default.json
@@ -40,17 +40,24 @@
       "extends": ["schedule:weekly"]
     },
     {
+      "description": "Opt-out minimum Go version updates: https://github.com/renovatebot/renovate/issues/16715",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "enabled": false
+    },
+    {
       "description": "Prefix lockFileMaintenance branches",
       "matchUpdateTypes": ["lockFileMaintenance"],
       "additionalBranchPrefix": "{{{manager}}}-",
       "commitMessagePrefix": "{{{semanticPrefix}}} {{{manager}}}"
     },
     {
-      "description": "Group golang updates and rename to Go",
-      "matchDatasources": ["docker", "golang-version"],
-      "matchPackageNames": ["go", "golang"],
-      "commitMessageTopic": "Go",
-      "groupName": "go"
+      "description": "Group golang docker tags and rename to Golang",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["golang"],
+      "matchPackagePatterns": ["/golang$"],
+      "commitMessageTopic": "Golang",
+      "groupName": "golang"
     },
     {
       "description": "Customize rust updates commit message",
@@ -78,7 +85,7 @@
       "semanticCommitType": "build"
     },
     {
-      "matchPackageNames": ["go", "node", "rust"],
+      "matchPackageNames": ["golang", "node", "rust"],
       "matchUpdateTypes": ["patch", "minor", "major"],
       "semanticCommitType": "build"
     },
@@ -113,8 +120,8 @@
       "description": "Update Golang in .go-version file",
       "fileMatch": ["(^|/)\\.go-version$"],
       "matchStrings": ["^\\s*(?<currentValue>.+?)\\s*$"],
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version"
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
     },
     {
       "description": "Update Rust stable version in rust-toolchain.toml",


### PR DESCRIPTION
Renovate now supports updating the Go version in `go.mod`, ~so we can drop our regex manager.
The `go.mod` updates use the `golang-version` datasource, so we use the same for `.go-version` to ensure we are in sync.~

Edit: but we do not want it

---

This also includes a couple minor fixes for Rust.