### PR TITLE
feat: support extractVersion in Regex managers

### DIFF
--- a/default.json
+++ b/default.json
@@ -115,21 +115,21 @@
       "description": "Update _VERSION variables in GitHub workflows",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s*[A-Z_]+?_VERSION: ('|\")?(?<currentValue>.+?)('|\")?\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s*[A-Z_]+?_VERSION: ('|\")?(?<currentValue>.+?)('|\")?\\s"
       ]
     },
     {
       "description": "Update _VERSION variables in Makefiles",
       "fileMatch": ["(^|/)Makefile$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s[A-Z_]+?_VERSION .?= (?<currentValue>.+?)\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s[A-Z_]+?_VERSION .?= (?<currentValue>.+?)\\s"
       ]
     },
     {
       "description": "Update _VERSION variables in shell scripts",
       "fileMatch": ["\\.sh$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s[A-Z_]+?_VERSION=('|\")?(?<currentValue>.+?)('|\")?\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s[A-Z_]+?_VERSION=('|\")?(?<currentValue>.+?)('|\")?\\s"
       ]
     },
     {


### PR DESCRIPTION
It is useful to trim the leading `v` for example, like in parca-dev/parca-agent#929, the action hardcodes it: [medyagh/setup-minikube@v0.0.8/src/minikube.ts#L92](https://github.com/medyagh/setup-minikube/blob/v0.0.8/src/minikube.ts#L92)

Reference: https://docs.renovatebot.com/modules/manager/regex/#required-fields