### PR TITLE
fix(renovate): enable helpers:pinGitHubActionDigestsToSemver preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,6 +10,7 @@
     ":rebaseStalePrs",
     ":semanticCommits",
     ":semanticCommitScope(deps)",
+    "helpers:pinGitHubActionDigestsToSemver",
     "regexManagers:dockerfileVersions",
     "regexManagers:githubActionsVersions"
   ],


### PR DESCRIPTION
E.g. Automatically turn `v1` tag into `v1.2.3` 

https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver